### PR TITLE
Fixed missing MYSQL_PORT parameter issue for misp_create_database.py

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -2,10 +2,6 @@
 # Copyright (C) 2022 National Cyber and Information Security Agency of the Czech Republic
 set -e
 
-if [ -z $MYSQL_PORT ]; then
-    MYSQL_PORT=3306
-fi
-
 if [ "$1" = 'supervisord' ]; then
     echo "======================================"
     echo "MISP $MISP_VERSION container image provided by National Cyber and Information Security Agency of the Czech Republic"
@@ -33,7 +29,7 @@ if [ "$1" = 'supervisord' ]; then
     php-fpm --test
 
     # Create database schema
-    su-exec apache misp_create_database.py $MYSQL_HOST $MYSQL_PORT $MYSQL_LOGIN $MYSQL_DATABASE /var/www/MISP/INSTALL/MYSQL.sql
+    su-exec apache misp_create_database.py $MYSQL_HOST $MYSQL_LOGIN $MYSQL_DATABASE /var/www/MISP/INSTALL/MYSQL.sql
 
     # Update database to latest version
     su-exec apache /var/www/MISP/app/Console/cake Admin runUpdates || true

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 # Copyright (C) 2022 National Cyber and Information Security Agency of the Czech Republic
 set -e
 
+if [ -z $MYSQL_PORT ]; then
+    MYSQL_PORT=3306
+fi
+
 if [ "$1" = 'supervisord' ]; then
     echo "======================================"
     echo "MISP $MISP_VERSION container image provided by National Cyber and Information Security Agency of the Czech Republic"
@@ -29,7 +33,7 @@ if [ "$1" = 'supervisord' ]; then
     php-fpm --test
 
     # Create database schema
-    su-exec apache misp_create_database.py $MYSQL_HOST $MYSQL_LOGIN $MYSQL_DATABASE /var/www/MISP/INSTALL/MYSQL.sql
+    su-exec apache misp_create_database.py $MYSQL_HOST $MYSQL_PORT $MYSQL_LOGIN $MYSQL_DATABASE /var/www/MISP/INSTALL/MYSQL.sql
 
     # Update database to latest version
     su-exec apache /var/www/MISP/app/Console/cake Admin runUpdates || true

--- a/bin/misp_create_database.py
+++ b/bin/misp_create_database.py
@@ -50,15 +50,19 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("host")
-    parser.add_argument("port", type=int)
     parser.add_argument("user")
     parser.add_argument("database")
     parser.add_argument("schema_file", type=argparse.FileType("r"))
     args = parser.parse_args()
 
     password = os.environ.get("MYSQL_PASSWORD")
+    port = os.environ.get("MYSQL_PORT")
+    if port is not None:
+        port = int(port)
+    else:
+        port = 3306
 
-    connection = wait_for_connection(args.host, args.port, args.user, password)
+    connection = wait_for_connection(args.host, port, args.user, password)
 
     if is_schema_created(connection, args.database):
         logging.info("Database schema is already created.")


### PR DESCRIPTION
The execution of misp_create_database.py results in a connection issue, when the configured MySQL Server doesn't use the default port (3306).
I fixed this issue by reading the MYSQL_PORT variable similar to the MYSQL_PASSWORD variable in misp_create_database.py. I also added some debug output which logs the sql server and the used port.
If the MYSQL_PORT  is not set in ENV, i set the port to 3306 so the definition is fully optional. This is required for logging.