### PR TITLE
JSON formatting in Rsyslog

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -37,6 +37,25 @@ $OmitLocalLogging off
 
 ### LOGS ###
 
+
+## Template to handle JSON formatting
+template(name="json" type="list") {
+  constant(value="{")
+  property(outname="timestamp" name="timereported" format="jsonf" dateFormat="rfc3339")
+  constant(value=",")
+  property(outname="loghost" name="$myhostname" format="jsonf")
+  constant(value=",")
+  property(outname="tag" name="syslogtag" format="jsonf")
+  constant(value=",")
+  property(outname="severity" name="syslogseverity" format="jsonf" datatype="number")
+  constant(value=",")
+  property(outname="message" name="msg" format="jsonf")
+  constant(value="}")
+  constant(value="\n")
+}
+
+template(name="text")
+
 module(load="imfile" PollingInterval="10")
 
 # Supervisord
@@ -101,5 +120,4 @@ input(type="imfile"
 
 # Ouput all logs to file
 action(type="omfile" dirCreateMode="0700" FileCreateMode="0644"
-       File="/var/log/messages")
-
+       File="/var/log/messages" template="json")

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -47,7 +47,7 @@ template(name="json" type="list") {
   constant(value=",")
   property(outname="tag" name="syslogtag" format="jsonf")
   constant(value=",")
-  property(outname="severity" name="syslogseverity" format="jsonf" datatype="number")
+  property(outname="severity" name="syslogseverity-text" format="jsonf")
   constant(value=",")
   property(outname="message" name="msg" format="jsonf")
   constant(value="}")


### PR DESCRIPTION
I have made an edit of rsyslog.conf to support JSON formatting and also log timestamp in rfc3339.

This will overrule the current log format, and if the developers still want the old format as option, it will be necessary to create another rsyslog template, and maybe control witch to use with environment variables. 