### PR TITLE
Config option for SECURITY_REST_CLIENT_ENABLE_ARBITRARY_URLS added

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -158,6 +158,7 @@ $config = [
     'hide_organisation_index_from_users' => {{ SECURITY_HIDE_ORGS | bool }},
     'hide_organisations_in_sharing_groups' => {{ SECURITY_HIDE_ORGS | bool }},
     'advanced_authkeys' => {{ SECURITY_ADVANCED_AUTHKEYS | bool }},
+    'rest_client_enable_arbitrary_urls' => {{ SECURITY_REST_CLIENT_ENABLE_ARBITRARY_URLS | bool }},
     {% if OIDC_LOGIN %}
     'auth' => ['OidcAuth.Oidc'],
     'auth_enforced' => true,

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ If you want to generate new PGP keys for email signing, you can do it by running
 * `SECURITY_HIDE_ORGS` (optional, boolean, default `false`) - hide org names for normal users
 * `SECURITY_ENCRYPTION_KEY` (optional, string) - encryption key with at least 32 chars that will be used to encrypt sensitive information stored in database *WARNING:* Never changed this value after deployment!
 * `SECURITY_CRYPTO_POLICY` (optional, string, default `DEFAULT:NO-SHA1`) - set container wide crypto policies. [More details](https://www.redhat.com/en/blog/consistent-security-crypto-policies-red-hat-enterprise-linux-8). Use empty string to keep container default value.
+* `SECURITY_REST_CLIENT_ENABLE_ARBITRARY_URLS` (optional, boolean, default `false`) - enable to query any arbitrary URL via rest client (required for Workflows Webhook).
 
 ### Outgoing proxy
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -151,6 +151,7 @@ VARIABLES = {
     "SECURITY_CRYPTO_POLICY": Option(default="DEFAULT:NO-SHA1"),
     "SECURITY_ENCRYPTION_KEY": Option(),
     "SECURITY_COOKIE_NAME": Option(),
+    "SECURITY_REST_CLIENT_ENABLE_ARBITRARY_URLS": Option(typ=bool, default=False),
     # PHP
     "PHP_XDEBUG_ENABLED": Option(typ=bool, default=False),
     "PHP_XDEBUG_PROFILER_TRIGGER": Option(),


### PR DESCRIPTION
Hi @ondj,

I've added a new Option for enabling rest_client_enable_arbitrary_urls, which is needed for Workflows Webhook.
As this option is CLI only, it should be set in the config file.