### PR TITLE
Use "additionalParameters" setting in Config/email.php

### DIFF
--- a/Config/email.php
+++ b/Config/email.php
@@ -13,5 +13,8 @@ class EmailConfig
         'log' => false,
         'tls' => true,
         'context' => ['ssl' => ['cafile' => '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem']],
+        {% if MISP_EMAIL_RETURN_PATH %}
+        'additionalParameters' => '-f '.{{ MISP_EMAIL_RETURN_PATH | str }},
+        {% endif %}
     ];
 }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HO
 * `MISP_HOST_ORG_ID` (optional, int, default `1`) - MISP default organisation ID
 * `MISP_MODULE_URL` (optional, string) - full URL to MISP modules
 * `MISP_DEBUG` (optional, boolean, default `false`) - enable debug mode (do not enable on production environment)
+* `MISP_EMAIL_RETURN_PATH` (optional, string) - mail address to use for the return path
 
 [Check more variables that allows MISP customization.](docs/CUSTOMIZATION.md)
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -141,6 +141,7 @@ VARIABLES = {
     "MISP_HOME_LOGO": Option(),
     "MISP_FOOTER_LOGO": Option(),
     "MISP_CUSTOM_CSS": Option(),
+    "MISP_EMAIL_RETURN_PATH": Option(),
     # Security
     "GNUPG_SIGN": Option(typ=bool, default=False),
     "GNUPG_PRIVATE_KEY_PASSWORD": Option(),


### PR DESCRIPTION
Use this variable to set the return path for mails being sent by MISP. By default this might be `username-running-misp@container_id` or something else which could expose internal names, or hinder senders being informed about bounced messages. 

compare with default configuration in [MISP / MISP/app/Config/email.php#L51](https://github.com/MISP/MISP/blob/2.4/app/Config/email.php#L51)
