### PR TITLE
Persist data in volumes by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Docker Compose file defines MISP itself, [MISP Modules](https://github.com/NUKIB
 
 Then you can access MISP in your browser by accessing `http://localhost:8080`. Default user after installation is `admin@admin.test` with password `admin`.
 
+To delete all volumes after testing, run:
+
+    docker-compose down -v
+
 ### Updating
 
 When a new MISP is released, also new container image is created. For updating MISP and MISP Modules, just run these commands in the folder that contains `docker-compose.yml` file.
@@ -44,7 +48,6 @@ These commands will download the latest images and recreate containers:
 For production usage, please:
 * change passwords for MariaDB and Redis,
 * modify environment variables to requested values,
-* set volumes location, so stored files will survive,
 * deploy reverse proxy (for example `nginx`) before MISP to handle HTTPS connections.
 
 ### Usage in air-gapped environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: misp-mysql
     tmpfs:
       - /tmp
+    volumes:
+      - mysql_data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: misp
       MYSQL_USER: misp
@@ -17,6 +19,8 @@ services:
     image: redis:7.0
     restart: always
     container_name: misp-redis
+    volumes:
+      - redis_data:/data
 
   misp-modules:
     image: ghcr.io/nukib/misp-modules:latest
@@ -61,3 +65,7 @@ services:
     ports:
       - 127.0.0.1:8080:80
       - 127.0.0.1:50000:50000
+
+volumes:
+  mysql_data:
+  redis_data:


### PR DESCRIPTION
The `docker-compose.yml` provided in the repository doesn't persist data by default.
Users that will take inspiration from this `docker-compose.yml` will have to lookup or just
know the volume storage locations inside the `mysql` or `redis` containers to let it run
in a persistent way.

To still allow developers to test out changes quickly, a command to delete volumes was also added to
the `README.md`. 
