### PR TITLE
new configuration option: OIDC_ROLES_PROPERTY

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -35,6 +35,7 @@ $oidcAuth = [
         'misp-api-access' => 'User with API access',
         'misp-access' => 3, // User
     ],
+    'roles_property' => {{ OIDC_ROLES_PROPERTY_INNER | str }},
     'organisation_property' => {{ OIDC_ORGANISATION_PROPERTY | str }},
     'default_org' => '{{ OIDC_DEFAULT_ORG if OIDC_DEFAULT_ORG else MISP_ORG }}',
     'unblock' => true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN bash /usr/local/bin/misp_enable_epel.sh && \
     dnf module -y enable mod_auth_openidc php:7.4 python39 && \
     dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y $(grep -vE "^\s*#" /tmp/packages | tr "\n" " ") && \
     alternatives --set python3 /usr/bin/python3.9 && \
+    alternatives --set python /usr/bin/python3.9 && \
     pip3 --no-cache-dir install --disable-pip-version-check -r /tmp/requirements.txt && \
     rm -rf /var/cache/dnf /tmp/packages
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -113,6 +113,8 @@ VARIABLES = {
     "OIDC_CLIENT_CRYPTO_PASS": Option(),
     "OIDC_DEFAULT_ORG": Option(),
     "OIDC_PASSWORD_RESET": Option(validation=check_is_url),
+    "OIDC_ROLES_PROPERTY": Option(default="roles"),
+    "OIDC_ROLES_PROPERTY_INNER": Option(),
     "OIDC_ORGANISATION_PROPERTY": Option(default="organization"),
     "OIDC_OFFLINE_ACCESS": Option(typ=bool, default=False),
     "OIDC_CHECK_USER_VALIDITY": Option(typ=int, default=0),
@@ -356,7 +358,7 @@ def main():
 
     variables["MISP_UUID"] = variables["MISP_UUID"].lower()
 
-    for var in ("OIDC_PROVIDER_INNER", "OIDC_CLIENT_ID_INNER", "OIDC_CLIENT_SECRET_INNER", "OIDC_AUTHENTICATION_METHOD_INNER", "OIDC_CODE_CHALLENGE_METHOD_INNER"):
+    for var in ("OIDC_PROVIDER_INNER", "OIDC_CLIENT_ID_INNER", "OIDC_CLIENT_SECRET_INNER", "OIDC_AUTHENTICATION_METHOD_INNER", "OIDC_CODE_CHALLENGE_METHOD_INNER", "OIDC_ROLES_PROPERTY_INNER"):
         if not variables[var]:
             variables[var] = variables[var.replace("_INNER", "")]
 

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -17,6 +17,7 @@ OIDC authentication is not used. Instead, Apache checks if a key is valid and le
 * `OIDC_PASSWORD_RESET` (optional, string) - URL to password reset page
 * `OIDC_CLIENT_CRYPTO_PASS` (optional, string) - password used for cookie encryption by Apache
 * `OIDC_DEFAULT_ORG` (optional, string) - default organisation name for a user that doesn't have organisation name in claim defined by `OIDC_ORGANISATION_PROPERTY` variable. If not provided `MISP_ORG` will be used.
+* `OIDC_ROLES_PROPERTY` (optional, string, default `roles`) - name of claim used for user roles in MISP
 * `OIDC_ORGANISATION_PROPERTY` (optional, string, default `organization`) - ID token or user info claim that will be used as an organisation in MISP
 * `OIDC_OFFLINE_ACCESS` (optional, boolean, default `false`) - if true, offline access token will be requested for user
 * `OIDC_CHECK_USER_VALIDITY` (optional, int, default `0`)
@@ -30,10 +31,11 @@ You can use a different provider for authentication in MISP. If you don't provid
 * `OIDC_CLIENT_SECRET_INNER` (optional, string, default value from `OIDC_CLIENT_SECRET`)
 * `OIDC_AUTHENTICATION_METHOD_INNER` (optional, string, default value from `OIDC_AUTHENTICATION_METHOD`)
 * `OIDC_CODE_CHALLENGE_METHOD_INNER` (optional, string, default value from `OIDC_CODE_CHALLENGE_METHOD_INNER`)
+* `OIDC_ROLES_PROPERTY_INNER` (optional, string, default value from `OIDC_ROLES_PROPERTY`)
 
 ## User Roles
 
-You can set the user role in MISP by modifying `role` claim in OIDC provider. By default, every user that wants to access 
+You can set the user role in MISP by modifying `roles` claim in OIDC provider. By default, every user that wants to access
 MISP must be assigned to `misp-access` role.
 
 ```php

--- a/misp.conf
+++ b/misp.conf
@@ -88,7 +88,7 @@ LogFormat "%h %{X-Request-Id}i %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agen
     </If>
     <Else>
         AuthType openid-connect
-        Require claim roles:misp-access
+        Require claim {{ OIDC_ROLES_PROPERTY }}:misp-access
     </Else>
     {% endif %}
 


### PR DESCRIPTION
Adds the possibility to override the `roles` claim name and to use different claims for the apache OIDC and the "inner" (MISP)
 configuration.

The enables use of e.g. AWS Cognito as the Identity Provider. AWS Cognito does not support returning a json array as a custom claim value, only strings. This patch enables a workaround where we send a single string value `"misp-access"` to pass the Apache
OIDC authorization, and we then send all authorized user roles in a separate claim to be parsed in the MISP OIDC ("inner") layer.