### PR TITLE
new configuration option: SMTP_PORT

### DIFF
--- a/Config/email.php
+++ b/Config/email.php
@@ -5,7 +5,7 @@ class EmailConfig
     public $default = [
         'transport' => 'Smtp',
         'host' => {{ SMTP_HOST | str }},
-        'port' => 25,
+        'port' => {{ SMTP_PORT | int }},
         'timeout' => 30,
         'username' => {{ SMTP_USERNAME | str }},
         'password' => {{ SMTP_PASSWORD | str }},

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HO
 
 ### Email setting
 
-* `SMTP_HOST` (optional, string) - SMTP server that will be used for sending emails. SMTP server must listen on port 25 and support STARTTLS.
+* `SMTP_HOST` (optional, string) - SMTP server that will be used for sending emails. SMTP server must support STARTTLS.
+* `SMTP_PORT` (optional, int, default `25`) - the TCP port for the SMTP host. Must support STARTTLS.
 * `SMTP_USERNAME` (optional, string)
 * `SMTP_PASSWORD` (optional, string)
 * `MISP_EMAIL` (required, string) - the email address that MISP should use for all notifications

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -130,6 +130,7 @@ VARIABLES = {
     "ZEROMQ_PASSWORD": Option(),
     # SMTP
     "SMTP_HOST": Option(),
+    "SMTP_PORT": Option(typ=int, default=25),
     "SMTP_USERNAME": Option(),
     "SMTP_PASSWORD": Option(),
     "SUPPORT_EMAIL": Option(validation=check_is_email),


### PR DESCRIPTION
Allows for using SMTP providers that do not support STARTTLS over port 25. 
In our case this is AWS SES when limiting access though a VPC endpoints, where we can use STARTTLS over e.g. port 587 instead.