### PR TITLE
new configuration option: GNUPG_PRIVATE_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HO
 ### PGP for email encryption and signing
 
 * `GNUPG_SIGN` (optional, boolean, default `false`) - sign outgoing emails by PGP
-* `GNUPG_PRIVATE_KEY_PASSWORD` (optional, string) - password for PGP key that is used to sign emails send by MISP
+* `GNUPG_PRIVATE_KEY` (optional, string) - private key used to sign emails sent by MISP
+* `GNUPG_PRIVATE_KEY_PASSWORD` (optional, string) - password for PGP private key used to sign emails sent by MISP
 * `GNUPG_BODY_ONLY_ENCRYPTED` (optional, boolean, default `false`)
 
-If you want to generate new PGP keys for email signing, you can do it by running this command inside the container:
+Alternatively, if you want to generate new PGP keys for email signing instead of
+providing a key using `GNUPG_PRIVATE_KEY`, you can do it by running this command
+inside the container:
 
     gpg --homedir /var/www/MISP/.gnupg --full-generate-key --pinentry-mode=loopback --passphrase "password"
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -57,6 +57,14 @@ chown -R apache:apache /var/www/MISP/.gnupg
 chmod 700 /var/www/MISP/.gnupg
 su-exec apache gpg --homedir /var/www/MISP/.gnupg --list-keys
 
+if [ -n "${GNUPG_PRIVATE_KEY}" -a -n "${GNUPG_PRIVATE_KEY_PASSWORD}" ]; then
+    # Import private key
+    su-exec apache gpg --homedir /var/www/MISP/.gnupg --import --batch \
+        --passphrase "${GNUPG_PRIVATE_KEY_PASSWORD}" <<< "${GNUPG_PRIVATE_KEY}"
+fi
+unset GNUPG_PRIVATE_KEY
+unset GNUPG_PRIVATE_KEY_PASSWORD
+
 # Change volumes permission to apache user
 chown apache:apache /var/www/MISP/app/attachments
 chown apache:apache /var/www/MISP/app/tmp/logs

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -154,6 +154,7 @@ VARIABLES = {
     # Security
     "GNUPG_SIGN": Option(typ=bool, default=False),
     "GNUPG_PRIVATE_KEY_PASSWORD": Option(),
+    "GNUPG_PRIVATE_KEY": Option(),
     "GNUPG_BODY_ONLY_ENCRYPTED": Option(typ=bool, default=False),
     "SECURITY_ADVANCED_AUTHKEYS": Option(typ=bool, default=False),
     "SECURITY_HIDE_ORGS": Option(typ=bool, default=False),


### PR DESCRIPTION
Support for installing a GPG private key through an environment variable. 

We do not want to install and persist the secret private key in the image itself. Instead we use our docker orchestrator 
(AWS ECS) which supports passing secrets (from System Manager Parameter Store) using environment variables.
There exists similar mechanisms for passing secrets in other orchestrators (e.g. Kubernetes) as well.