### PR TITLE
Add cryptography package to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography
 pymisp
 lief
 python-magic


### PR DESCRIPTION
Add package cryptography to requirements to support the default encryption used by MySQL 8.

We use MySQL 8 and the default authentication module requires the cryptography to be installed. Without it the following error is logged and MISP can't connect to MySQL.

2023-05-25 03:19:15,802 - INFO: Waiting for database connection...
2023-05-25 03:19:15,803 - INFO: 'cryptography' package is required for sha256_password or caching_sha2_password auth methods