### PR TITLE
Added OIDC_TOKEN_SIGNED_ALGORITHM setting to support explicit algorithm choice

### DIFF
--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -118,6 +118,7 @@ VARIABLES = {
     "OIDC_ORGANISATION_PROPERTY": Option(default="organization"),
     "OIDC_OFFLINE_ACCESS": Option(typ=bool, default=False),
     "OIDC_CHECK_USER_VALIDITY": Option(typ=int, default=0),
+    "OIDC_TOKEN_SIGNED_ALGORITHM": Option(),
     # Logging
     "SYSLOG_TARGET": Option(),
     "SYSLOG_PORT": Option(typ=int, default=601),

--- a/docs/OIDC.md
+++ b/docs/OIDC.md
@@ -1,6 +1,6 @@
 # OpenID Connect (OIDC) login
 
-This Docker image is prepared to use OIDC for login into MISP. To enhance security, OIDC is implemented right into Apache by [mod_auth_openidc](https://github.com/zmartzone/mod_auth_openidc)
+This Docker image is prepared to use OIDC for login into MISP. To enhance security, OIDC is implemented right into Apache by [mod_auth_openidc](https://github.com/OpenIDC/mod_auth_openidc)
 and also in MISP itself. That means that unauthenticated users will stop right on Apache.
 
 If a request to MISP is made with `Authorization` header, that contains an authentication key in MISP format,
@@ -21,6 +21,7 @@ OIDC authentication is not used. Instead, Apache checks if a key is valid and le
 * `OIDC_ORGANISATION_PROPERTY` (optional, string, default `organization`) - ID token or user info claim that will be used as an organisation in MISP
 * `OIDC_OFFLINE_ACCESS` (optional, boolean, default `false`) - if true, offline access token will be requested for user
 * `OIDC_CHECK_USER_VALIDITY` (optional, int, default `0`)
+* `OIDC_TOKEN_SIGNED_ALGORITHM` (optional, string) - can be any of `RS256|RS384|RS512|PS256|PS384|PS512|HS256|HS384|HS512|ES256|ES384|ES512`, the algorithms supported by `mod_auth_openidc` (the Apache OIDC-module), leaving empty will make `mod_auth_openidc` default to `RS256` 
 
 ### Inner
 

--- a/misp.conf
+++ b/misp.conf
@@ -77,6 +77,9 @@ LogFormat "%h %{X-Request-Id}i %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agen
     {% if OIDC_CODE_CHALLENGE_METHOD %}
     OIDCPKCEMethod {{ OIDC_CODE_CHALLENGE_METHOD }}
     {% endif %}
+    {% if OIDC_TOKEN_SIGNED_ALGORITHM %}
+    OIDCIDTokenSignedResponseAlg {{ OIDC_TOKEN_SIGNED_ALGORITHM }}
+    {% endif %}
     #OIDCScope "openid email"
 
     OIDCHTMLErrorTemplate /var/www/html/oidc.html


### PR DESCRIPTION
PR to allow other algorithms for signing tokens.

I have verified that the changes work in our environment, but these changes should be verified by other before merging (I think).

The PR add a `OIDC_TOKEN_SIGNED_ALGORITHM` variable which can be set through, for example, docker-compose-files. The argument is not verified in any way, and is just passed through to `mod_auth_openidc`. 

This allows advanced users to select a potentially more secure algorithm. 