### PR TITLE
Add Azure AD implementation

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -117,6 +117,9 @@ CakePlugin::load('OidcAuth');
  */
 // CakePlugin::load('CertAuth');
 // CakePlugin::load('ShibbAuth');
+{% if AZURE_LOGIN %}
+CakePlugin::load('AadAuth');
+{% endif %}
 
 /**
  * Configures default file logging options
@@ -142,4 +145,3 @@ CakeLog::config('syslog', array(
 if (in_array('phar', stream_get_wrappers(), true)) {
     stream_wrapper_unregister('phar');
 }
-

--- a/Config/config.php
+++ b/Config/config.php
@@ -105,6 +105,20 @@ $config = [
     'custom_css' => {{ MISP_CUSTOM_CSS | str }},
     'tmpdir' => '/tmp',
   ],
+  {% if AZURE_LOGIN %}
+  'AadAuth' => [
+    'client_id' => '{{ AZURE_CLIENT_ID }}', // Client ID (see Azure AD)
+    'ad_tenant' => '{{ AZURE_AD_TENANT }}', // Directory ID (see Azure AD)
+    'client_secret' => '{{ AZURE_CLIENT_SECRET }}', // Client secret (see Azure AD)
+    'redirect_uri' => '{{ AZURE_REDIRECT_URI }}', // Your MISP URI, must be the same as in Azure AD
+    'auth_provider' => 'https://login.microsoftonline.com/', // No change required
+    'auth_provider_user' => 'https://graph.microsoft.com/', // No change required
+    'misp_user' => '{{ AZURE_MISP_USER_GROUP }}', // The AD group for MISP users
+    'misp_orgadmin' => '{{ AZURE_MISP_ORGADMIN_GROUP }}', // The AD group for MISP administrators
+    'misp_siteadmin' => '{{ AZURE_MISP_SITEADMIN_GROUP }}', // The AD group for MISP site administrators
+    'check_ad_groups' => {{ AZURE_CHECK_AD_GROUPS }}, // Should we check if the user belongs to one of the above AD groups?
+  ],
+  {% endif %}
   'SimpleBackgroundJobs' => [
     'enabled' => true,
     'redis_host' => '{{ REDIS_HOST }}',
@@ -142,6 +156,11 @@ $config = [
     'expire' => 300,
   ],
   'Security' => [
+    {% if AZURE_LOGIN %}
+    'auth' => [
+      0 => 'AadAuth.AadAuthenticate',
+    ],
+    {% endif %}
     'force_https' => {{ 'true' if MISP_BASEURL.startswith('https://') else 'false' }},
     'csp_enforce' => true,
     'min_tls_version' => 'tlsv1_2',

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -182,6 +182,16 @@ VARIABLES = {
     "JOBBER_LOG_ROTATE_TIME": Option(default="0 0 5"),
     "JOBBER_USER_CHECK_VALIDITY_TIME": Option(default="0 0 5"),
     "JOBBER_SEND_PERIODIC_SUMMARY": Option(default="0 0 6 * * 1-5"),
+    # Azure AD
+    "AZURE_LOGIN": Option(typ=bool),
+    "AZURE_CLIENT_ID": Option(),
+    "AZURE_AD_TENANT": Option(),
+    "AZURE_CLIENT_SECRET": Option(),
+    "AZURE_REDIRECT_URI": Option(validation=check_is_url),
+    "AZURE_MISP_USER_GROUP": Option(),
+    "AZURE_MISP_ORGADMIN_GROUP": Option(),
+    "AZURE_MISP_SITEADMIN_GROUP": Option(),
+    "AZURE_CHECK_AD_GROUPS": Option(typ=bool),
 }
 
 
@@ -377,7 +387,13 @@ def main():
         if "/.well-known/openid-configuration" not in variables["OIDC_PROVIDER"]:
             variables["OIDC_PROVIDER"] = f"{variables['OIDC_PROVIDER'].rstrip('/')}/.well-known/openid-configuration"
 
-    for template_name in ("database.php", "config.php", "email.php"):
+    if variables["AZURE_LOGIN"]:
+        variables["AZURE_CHECK_AD_GROUPS"] = str(variables["AZURE_CHECK_AD_GROUPS"]).lower()
+        for var in ("AZURE_CLIENT_ID", "AZURE_AD_TENANT", "AZURE_CLIENT_SECRET", "AZURE_REDIRECT_URI", "AZURE_MISP_USER_GROUP", "AZURE_MISP_ORGADMIN_GROUP", "AZURE_MISP_SITEADMIN_GROUP", "AZURE_CHECK_AD_GROUPS"):
+            if not variables[var]:
+                error(f"Azure login is enabled, but '{var}' environment variable is not set")
+
+    for template_name in ("database.php", "config.php", "email.php", "bootstrap.php"):
         path = f"/var/www/MISP/app/Config/{template_name}"
         render_jinja_template(path, variables)
 


### PR DESCRIPTION
The goal of this pull request is to implement AzureAD directly without having to use OIDC which is painful to deploy (I couldn't do it).
It's basically adding the needed variables into the Python script and adding some new options in `config.php` and `bootstrap.php` (that will now be rendered also as it contain a variable).
I've just followed these steps : https://github.com/MISP/MISP/tree/2.4/app/Plugin/AadAuth.