### PR TITLE
Ensure all required Python packages are installed for TAXII push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN bash /usr/local/bin/misp_enable_epel.sh && \
     dnf install --setopt=tsflags=nodocs --setopt=install_weak_deps=False -y $(grep -vE "^\s*#" /tmp/packages | tr "\n" " ") && \
     alternatives --set python3 /usr/bin/python3.11 && \
     alternatives --set python /usr/bin/python3.11 && \
-    pip3 --no-cache-dir install --disable-pip-version-check -r /tmp/requirements.txt && \
     rm -rf /var/cache/dnf /tmp/packages
 
 COPY --from=builder /usr/local/bin/su-exec /usr/local/bin/

--- a/bin/misp_install.sh
+++ b/bin/misp_install.sh
@@ -61,6 +61,9 @@ su-exec apache git config core.filemode false
 cd /var/www/MISP/app/files/
 su-exec apache git submodule update --depth 1 --init --recursive .
 
+# Install Python dependencies
+pip3 --no-cache-dir install --disable-pip-version-check -r /tmp/requirements.txt
+
 # Install MISP composer dependencies
 cd /var/www/MISP/app
 # require exact version of `symfony/polyfill-php80` to keep compatibility, because later version replaces Attribute class :/

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,9 @@ pytz
 pydeep2
 simplejson
 stix2-patterns>=1.2.0
+taxii2-client
+cryptography
+/var/www/MISP/app/files/scripts/cti-python-stix2
+/var/www/MISP/app/files/scripts/misp-stix
+/var/www/MISP/app/files/scripts/mixbox
+/var/www/MISP/app/files/scripts/python-stix


### PR DESCRIPTION
When trying to do a "push to TAXII server" from the "Linked TAXII Servers" page, I would always see the following error in the `exec-errors.log`:
```
[2023-07-19 21:02:20 417] Running command python3 /var/www/MISP/app/files/scripts/taxii/taxii_push.py --dir /tmp/Taxii/31WFfqecOd3h --baseurl http://medallion:5000/ --api_root trustgroup1 --key [REDACTED] --collection 365fed99-08fa-fdcd-a1b3-fb247eb41d01
Traceback (most recent call last):
  File "/var/www/MISP/app/files/scripts/taxii/taxii_push.py", line 9, in <module>
    import taxii2client
ModuleNotFoundError: No module named 'taxii2client'
[2023-07-19 21:02:20 417] Process finished with return code 1
```

Adding that package to the container's `requirements.txt` resulted in additional libraries it couldn't find, including several that are submoduled in the MISP codebase, but don't seem to actually be getting installed into the Python search path.

This is a PR to ensure that all libraries needed for the TAXII push functionality are installed into the containers Python environment, using the versions included in the MISP codebase, if possible.  I had to move the package installation to _after_ the git checkout for this to work.

With this change (and a version bump to MISP `v2.4.173` to pick up [this fix](https://github.com/MISP/MISP/commit/c2ca52e83b1bcbcd274331f98899a2f42a828412), I was able to successfully push events from a MISP server to a TAXII server.
