### PR TITLE
Add python3.11-cryptography for use with default MySQL

### DIFF
--- a/packages
+++ b/packages
@@ -16,6 +16,7 @@ python3.11-idna
 python3.11-lxml
 python3.11-ply
 python3.11-PyMySQL
+python3.11-cryptography
 
 # PHP
 php-cli


### PR DESCRIPTION
The package python3.11-cryptography is needed to be able to connect to MySQL databases that uses "sha256_password" or "caching_sha2_password" for authentication. I hope that it would be possible to add it since my organisation and maybe others use MySQL as our database and we are encouraged to use MySQL from our IT instead of running databases in Docker.

See https://github.com/PyMySQL/PyMySQL for the requirements for PyMySQL[rsa].