### PR TITLE
Allow voluming in custom taxonomy files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ VOLUME /var/www/MISP/app/tmp/logs/
 VOLUME /var/www/MISP/app/files/certs/
 VOLUME /var/www/MISP/app/attachments/
 VOLUME /var/www/MISP/.gnupg/
+VOLUME /var/www/MISP/app/files.dist/taxonomies/
 
 WORKDIR /var/www/MISP/
 # Web server

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ If one of the variables is set to `0`, no workers will be started.
 * `/var/www/MISP/app/files/certs/` - uploaded certificates used for accessing remote feeds and servers
 * `/var/www/MISP/app/attachments/` - uploaded attachments and malware samples
 * `/var/www/MISP/.gnupg/` - GPG homedir
+* `/var/www/MISP/app/files.dist/taxonomies/` - custom taxonomies to be loaded at startup
 
 ## License
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -66,8 +66,8 @@ unset GNUPG_PRIVATE_KEY
 unset GNUPG_PRIVATE_KEY_PASSWORD
 
 # Copy over any custom taxonomy files
-if [ -d /var/www/MISP/app/files.dist/taxonomies ]; then
-    cp -r /var/www/MISP/app/files.dist/taxonomies/* /var/www/MISP/app/files/taxonomies/
+if [ -d /var/www/MISP/app/files.dist/taxonomies/ ]; then
+    cp -r /var/www/MISP/app/files.dist/taxonomies/* /var/www/MISP/app/files/taxonomies/ || :
     chmod 750 /var/www/MISP/app/files/taxonomies/*
 fi
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -65,6 +65,12 @@ fi
 unset GNUPG_PRIVATE_KEY
 unset GNUPG_PRIVATE_KEY_PASSWORD
 
+# Copy over any custom taxonomy files
+if [ -d /var/www/MISP/app/files.dist/taxonomies ]; then
+    cp -r /var/www/MISP/app/files.dist/taxonomies/* /var/www/MISP/app/files/taxonomies/
+    chmod 750 /var/www/MISP/app/files/taxonomies/*
+fi
+
 # Change volumes permission to apache user
 chown apache:apache /var/www/MISP/app/attachments
 chown apache:apache /var/www/MISP/app/tmp/logs


### PR DESCRIPTION
Added support for voluming in custom taxonomy files to be loaded on startup.  Because MISP has very specific requirements about the permissions of the taxonomy files, so we volume the files into `files.dist` and copy them over to `files` and set the permissions there.  Haven't figured out a better way to make this work than that.  This is the same method used by https://github.com/coolacid/docker-misp.