### PR TITLE
Add configuration for HTTP port and HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ VOLUME /var/www/MISP/app/tmp/logs/
 VOLUME /var/www/MISP/app/files/certs/
 VOLUME /var/www/MISP/app/attachments/
 VOLUME /var/www/MISP/.gnupg/
+VOLUME /etc/pki/tls
 
 WORKDIR /var/www/MISP/
 # Web server

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HO
 * `MISP_HOST_ORG_ID` (optional, int, default `1`) - MISP default organisation ID
 * `MISP_MODULE_URL` (optional, string) - full URL to MISP modules
 * `MISP_DEBUG` (optional, boolean, default `false`) - enable debug mode (do not enable on production environment)
+* `MISP_PORT (optional, int, default `80`) - port to serve MISP web interface on
+* `MISP_USE_SSL` (optional, boolean, default `false`) - enable to serve MISP web interface over HTTPS
 
 [Check more variables that allows MISP customization.](docs/CUSTOMIZATION.md)
 
@@ -229,6 +231,7 @@ If one of the variables is set to `0`, no workers will be started.
 * `/var/www/MISP/app/files/certs/` - uploaded certificates used for accessing remote feeds and servers
 * `/var/www/MISP/app/attachments/` - uploaded attachments and malware samples
 * `/var/www/MISP/.gnupg/` - GPG homedir
+* `/etc/pik/tls` - certificates to serve MISP over HTTPS
 
 ## License
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -152,6 +152,8 @@ VARIABLES = {
     "MISP_HOME_LOGO": Option(),
     "MISP_FOOTER_LOGO": Option(),
     "MISP_CUSTOM_CSS": Option(),
+    "MISP_PORT": Option(typ=int, default=80),
+    "MISP_USE_SSL": Option(typ=bool, default=False),
     # Security
     "GNUPG_SIGN": Option(typ=bool, default=False),
     "GNUPG_PRIVATE_KEY_PASSWORD": Option(),
@@ -235,6 +237,7 @@ def render_jinja_template(path: str, variables: dict):
 
 
 def generate_apache_config(variables: dict):
+    os.remove("/etc/httpd/conf.d/ssl.conf")
     render_jinja_template("/etc/httpd/conf.d/misp.conf", variables)
 
 

--- a/misp.conf
+++ b/misp.conf
@@ -2,11 +2,23 @@ ServerTokens Prod
 
 ServerName {{ SERVER_NAME }}
 
+{% if MISP_USE_SSL %}
+LoadModule ssl_module modules/mod_ssl.so
+{% endif %}
+
 # Include request ID header in accesss log
 LogFormat "%h %{X-Request-Id}i %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 
-<VirtualHost *:80>
+Listen {{ MISP_PORT }}
+
+<VirtualHost *:{{ MISP_PORT }}>
     DocumentRoot /var/www/MISP/app/webroot
+
+    {% if MISP_USE_SSL %}
+    SSLEngine On
+    SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+    SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+    {% endif %}
 
     ErrorDocument 401 /401.html
     ErrorDocument 403 /401.html

--- a/packages
+++ b/packages
@@ -1,6 +1,7 @@
 git-core
 httpd
 mod_auth_openidc
+mod_ssl
 zip
 supervisor
 ssdeep-libs


### PR DESCRIPTION
Add configuration options to the container to allow the port MISP listens on to be set, and allow HTTPS to be enabled.  Add a volume point to allow certificates for HTTPS to be volumed in.