### PR TITLE
new configuration option: REDIS_USE_TLS

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -8,7 +8,7 @@ $plugin['ZeroMQ_enable'] = true;
 $plugin['ZeroMQ_username'] = '{{ ZEROMQ_USERNAME }}';
 $plugin['ZeroMQ_password'] = {{ ZEROMQ_PASSWORD | str }};
 {% endif %}
-$plugin['ZeroMQ_redis_host'] = '{{ REDIS_HOST }}';
+$plugin['ZeroMQ_redis_host'] = '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}';
 $plugin['ZeroMQ_redis_port'] = 6379;
 $plugin['ZeroMQ_redis_password'] = {{ REDIS_PASSWORD | str }};
 $plugin['ZeroMQ_redis_database'] = 10;
@@ -78,7 +78,7 @@ $config = [
     'unpublishedprivate' => true,
     'uuid' => '{{ MISP_UUID }}',
     'host_org_id' => {{ MISP_HOST_ORG_ID }},
-    'redis_host' => '{{ REDIS_HOST }}',
+    'redis_host' => '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}',
     'redis_port' => 6379,
     'redis_database' => 13,
     'redis_password' => {{ REDIS_PASSWORD | str }},
@@ -107,7 +107,7 @@ $config = [
   ],
   'SimpleBackgroundJobs' => [
     'enabled' => true,
-    'redis_host' => '{{ REDIS_HOST }}',
+    'redis_host' => '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}',
     'redis_port' => 6379,
     'redis_password' => {{ REDIS_PASSWORD | str }},
     'redis_database' => 11,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HO
 
 * `REDIS_HOST` (required, string) - hostname or IP address
 * `REDIS_PASSWORD` (optional, string) - password used to connect password protected Redis instance
+* `REDIS_USE_TLS` (optional, bool) - enable encrypted communication
 
 #### Default Redis databases
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -92,6 +92,7 @@ VARIABLES = {
     # Redis
     "REDIS_HOST": Option(required=True),
     "REDIS_PASSWORD": Option(),
+    "REDIS_USE_TLS": Option(typ=bool, default=False),
     # Proxy
     "PROXY_HOST": Option(),
     "PROXY_PORT": Option(typ=int, default=3128),
@@ -273,11 +274,12 @@ def generate_snuffleupagus_config(enabled: bool):
     write_file("/etc/php.d/40-snuffleupagus.ini", config)
 
 
-def generate_sessions_in_redis_config(enabled: bool, redis_host: str, redis_password: Optional[str] = None):
+def generate_sessions_in_redis_config(enabled: bool, redis_host: str, redis_use_tls: Optional[bool] = False, redis_password: Optional[str] = None):
     if not enabled:
         return
 
-    redis_path = f"tcp://{redis_host}:6379?database=12"
+    scheme = "tls" if redis_use_tls else "tcp"
+    redis_path = f"{scheme}://{redis_host}:6379?database=12"
     if redis_password:
         redis_path = f"{redis_path}&auth={redis_password}"
 
@@ -393,7 +395,7 @@ def main():
 
     generate_xdebug_config(variables["PHP_XDEBUG_ENABLED"], variables["PHP_XDEBUG_PROFILER_TRIGGER"])
     generate_snuffleupagus_config(variables['PHP_SNUFFLEUPAGUS'])
-    generate_sessions_in_redis_config(variables["PHP_SESSIONS_IN_REDIS"], variables["REDIS_HOST"], variables["REDIS_PASSWORD"])
+    generate_sessions_in_redis_config(variables["PHP_SESSIONS_IN_REDIS"], variables["REDIS_HOST"], variables["REDIS_USE_TLS"], variables["REDIS_PASSWORD"])
     generate_apache_config(variables)
     generate_rsyslog_config(variables)
     generate_error_messages(variables["SUPPORT_EMAIL"])


### PR DESCRIPTION
This allows for encrypted communication between MISP and redis. 
Without this the redis password will be sent in plain-text.