### PR TITLE
Adjusted location of zstd-1.5.6

### DIFF
--- a/bin/misp_compile_php_extensions.sh
+++ b/bin/misp_compile_php_extensions.sh
@@ -40,7 +40,7 @@ mkdir /tmp/zstd
 cd /tmp/zstd
 download_and_check https://github.com/kjdev/php-ext-zstd/archive/refs/tags/0.13.3.tar.gz 547f84759c2177f4415ae4a5d5066f09d2979f06aa2b3b4b97b42c0990a1efc5
 cd zstd
-download_and_check https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz 8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1
+download_and_check https://github.com/facebook/zstd/archive/refs/tags/v1.5.6.tar.gz 30f35f71c1203369dc979ecde0400ffea93c27391bfd2ac5a9715d2173d92ff7
 cd ..
 phpize
 ./configure --silent


### PR DESCRIPTION
The current build fails due to zstd-1.5.6 is not available as a release but only a tag. Possibly re-release based on commit msg (https://github.com/facebook/zstd/releases/tag/v1.5.6)

Adjusted URL for package and sha256, builds clean in my repo.