### PR TITLE
python: Temporary install PyMISP from Git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymisp
+git+https://github.com/MISP/PyMISP.git
 lief
 python-magic
 plyara


### PR DESCRIPTION
This will fix converting stix2misp, can be reverted after PyMISP 2.4.189 is released.