### PR TITLE
Add configuration options for DB settings and flags

### DIFF
--- a/Config/database.php
+++ b/Config/database.php
@@ -11,6 +11,20 @@ class DATABASE_CONFIG {
         'database' => '{{ MYSQL_DATABASE }}',
         'prefix' => '',
         'encoding' => 'utf8',
-        'settings' => ['time_zone' => '"+00:00"'],
+        'settings' => [
+            'time_zone' => '"+00:00"',
+    {% if MYSQL_SETTINGS -%}
+        {% for setting, value in MYSQL_SETTINGS.items() %}
+            '{{ setting }}' => '{{ value }}',
+        {% endfor %}
+    {%- endif %}
+        ],
+{% if MYSQL_FLAGS %}
+        'flags' => [
+    {% for flag, value in MYSQL_FLAGS.items() %}
+            '{{ flag }}' => '{{ value }}',
+    {% endfor %}
+        ]
+{% endif %}
     ];
 }

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ MISP requires MySQL or MariaDB database.
 * `MYSQL_LOGIN` (required, string) - database user
 * `MYSQL_PASSWORD` (optional, string)
 * `MYSQL_DATABASE` (required, string) - database name
+* `MYSQL_SETTINGS` (optional, string) - database settings, which should be set for each db connection (JSON dict, or semicolon separated key value pairs)
+* `MYSQL_FLAGS` (required, string) - PDO flags which should be set for each db connection (JSON dict, or semicolon separated key value pairs)
 
 ### Redis
 


### PR DESCRIPTION
This update adds configuration options for db settings and db flags which are added into the database.php configuration file.
I need the settings option for the workaround mentioned here: [Support: PDO error "There is already an active transaction" after upgrade to 2.5](https://github.com/MISP/MISP/issues/10106#issuecomment-2551064158). I have only implemented the flags option for the sake of completeness.