### PR TITLE
S3 support: MinIO env vars depricated (MinIO is used in test pipeline)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -61,16 +61,18 @@ jobs:
     -
       name: Test
       env:
+        MISP_USER: admin@admin.test # default user
         BUCKET_NAME: ${{ env.BUCKET_NAME }}
         S3_ACCESS_KEY: ${{ env.MINIO_ROOT_USER }}
-        S3_SECRET_KEY: ${{ env.MINIO_ROOT_PASSWORD }}    
+        S3_SECRET_KEY: ${{ env.MINIO_ROOT_PASSWORD }}
       run: |
         cat .github/workflows/test/.test-env.sh >> ./.env_s3
         docker history ${{ env.TEST_TAG }}
         MISP_IMAGE=${{ env.TEST_TAG }} docker compose up --detach --quiet-pull
         sleep 15 # Wait until container is ready
         docker logs misp
-        AUTHKEY=$(docker exec misp su-exec apache /var/www/MISP/app/Console/cake user init)
+        docker exec misp su-exec apache /var/www/MISP/app/Console/cake user init # Ensure default user init
+        AUTHKEY=$(docker exec misp su-exec apache /var/www/MISP/app/Console/cake user change_authkey $MISP_USER | sed -n -e 's/Authentication key changed to: //p')
         VERSION=$(curl --fail -v -H "Authorization: $AUTHKEY" -H "Accept: application/json" http://localhost:8080/servers/getVersion)
         echo $VERSION | jq
         .github/workflows/test/test_minio.sh $S3_ACCESS_KEY $S3_SECRET_KEY $BUCKET_NAME $AUTHKEY

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,8 +17,8 @@ env:
   # See https://github.com/goodwithtech/dockle/issues/188
   DOCKLE_HOST: "unix:///var/run/docker.sock"
   BUCKET_NAME: testbucket
-  MINIO_ACCESS_KEY: testuser 
-  MINIO_SECRET_KEY: i5Qkesr8fbV0Vezn0zojaIyKvnObUtNMXFu38wlT
+  MINIO_ROOT_USER: testuser 
+  MINIO_ROOT_PASSWORD: i5Qkesr8fbV0Vezn0zojaIyKvnObUtNMXFu38wlT
 
 jobs:
   build:
@@ -62,8 +62,8 @@ jobs:
       name: Test
       env:
         BUCKET_NAME: ${{ env.BUCKET_NAME }}
-        S3_ACCESS_KEY: ${{ env.MINIO_ACCESS_KEY }}
-        S3_SECRET_KEY: ${{ env.MINIO_SECRET_KEY }}    
+        S3_ACCESS_KEY: ${{ env.MINIO_ROOT_USER }}
+        S3_SECRET_KEY: ${{ env.MINIO_ROOT_PASSWORD }}    
       run: |
         cat .github/workflows/test/.test-env.sh >> ./.env_s3
         docker history ${{ env.TEST_TAG }}

--- a/.github/workflows/test/test_minio.sh
+++ b/.github/workflows/test/test_minio.sh
@@ -21,7 +21,7 @@ fi
 
 echo "Setup MinIO container"
 NETWORK=$(docker inspect misp --format="{{ .HostConfig.NetworkMode }}")
-docker run -d --expose 9000 --network $NETWORK -e MINIO_ROOT_USER=$MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD --quiet --name minio ghcr.io/elri/minio-cicd:latest
+docker run -d --expose 9000 --network $NETWORK -e MINIO_ROOT_USER=$MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD --quiet --name minio quay.io/minio/minio:latest server /data
 
 echo "Ensure MinIO client exists"
 curl -o ./mc -# https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x ./mc

--- a/.github/workflows/test/test_minio.sh
+++ b/.github/workflows/test/test_minio.sh
@@ -21,7 +21,7 @@ fi
 
 echo "Setup MinIO container"
 NETWORK=$(docker inspect misp --format="{{ .HostConfig.NetworkMode }}")
-docker run -d --expose 9000 --network $NETWORK -e MINIO_ROOT_USER=$MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD --quiet --name minio ghcr.io/cparta/minio-cicd:latest
+docker run -d --expose 9000 --network $NETWORK -e MINIO_ROOT_USER=$MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD --quiet --name minio ghcr.io/elri/minio-cicd:latest
 
 echo "Ensure MinIO client exists"
 curl -o ./mc -# https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x ./mc

--- a/.github/workflows/test/test_minio.sh
+++ b/.github/workflows/test/test_minio.sh
@@ -9,19 +9,19 @@
 # MinIO container is put on same bridge network as MISP
 # MinIO client (mc) and MISP REST API is used 
 
-MINIO_ACCESS_KEY=$1
-MINIO_SECRET_KEY=$2
+MINIO_ROOT_USER=$1
+MINIO_ROOT_PASSWORD=$2
 BUCKET_NAME=$3
 AUTHKEY=$4
 
-if [[ (-z MINIO_ACCESS_KEY) || (-z MINIO_SECRET_KEY) || (-z BUCKET_NAME) || (-z AUTHKEY) ]]; then
-    echo "Missing env vars: "  $MINIO_ACCESS_KEY "/" $MINIO_SECRET_KEY "/" $BUCKET_NAME "/" $AUTHKEY
+if [[ (-z MINIO_ROOT_USER) || (-z MINIO_ROOT_PASSWORD) || (-z BUCKET_NAME) || (-z AUTHKEY) ]]; then
+    echo "Missing env vars: "  $MINIO_ROOT_USER "/" $MINIO_ROOT_PASSWORD "/" $BUCKET_NAME "/" $AUTHKEY
 fi
 
 
 echo "Setup MinIO container"
 NETWORK=$(docker inspect misp --format="{{ .HostConfig.NetworkMode }}")
-docker run -d --expose 9000 --network $NETWORK -e MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY -e MINIO_SECRET_KEY=$MINIO_SECRET_KEY --quiet --name minio ghcr.io/cparta/minio-cicd:latest
+docker run -d --expose 9000 --network $NETWORK -e MINIO_ROOT_USER=$MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD --quiet --name minio ghcr.io/cparta/minio-cicd:latest
 
 echo "Ensure MinIO client exists"
 curl -o ./mc -# https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x ./mc
@@ -29,7 +29,7 @@ curl -o ./mc -# https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x .
 echo "Create bucket"
 MINIO_IP=$(docker inspect minio --format="{{ .NetworkSettings.Networks.$NETWORK.IPAddress }}")
 echo "Minio IP" $MINIO_IP
-./mc alias set minio http://$MINIO_IP:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+./mc alias set minio http://$MINIO_IP:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
 ./mc mb minio/$BUCKET_NAME 
 
 echo "Create event"


### PR DESCRIPTION
`MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` are now deprecated, see [MinIO docs: MinIO root User](https://min.io/docs/minio/linux/administration/identity-access-management/minio-user-management.html#minio-root-user).

Changes in this MR: 
- `MINIO_ROOT_USER` replaces `MINIO_ACCESS_KEY`
- `MINIO_ROOT_PASSWORD` replaces `MINIO_SECRET_KEY`
- MISP authkey fetched separate from user init
- Using quay.io/minio image directly 

