### PR TITLE
Remove quoutes around database flags

### DIFF
--- a/Config/database.php
+++ b/Config/database.php
@@ -22,7 +22,7 @@ class DATABASE_CONFIG {
 {% if MYSQL_FLAGS %}
         'flags' => [
     {% for flag, value in MYSQL_FLAGS.items() %}
-            '{{ flag }}' => '{{ value }}',
+            {{ flag }} => {{ value }},
     {% endfor %}
         ]
 {% endif %}


### PR DESCRIPTION
NOTE: I have not yet tested this due to lack of proper environment, will try to do so ASAP if you cant.

Removed the single qoutes around  {{ flag }} => {{ value }} since the config does not work with them in place. According to https://github.com/MISP/MISP/blob/2.5/app/Config/database.default.php the database flags should be without quoutes.

Note that MISP2.5 requres the flag 
        'flags' => [
            PDO::ATTR_STRINGIFY_FETCHES => true
        ]

to have the API work as expected so this might be hardcoded in? I dont know if 2.4 compability is still needed.