### PR TITLE
Update Snuffleupagus to 0.12.0

### DIFF
--- a/bin/misp_compile_php_extensions.sh
+++ b/bin/misp_compile_php_extensions.sh
@@ -96,7 +96,7 @@ mv modules/*.so /build/php-modules/
 # Compile snuffleupagus
 mkdir /tmp/snuffleupagus
 cd /tmp/snuffleupagus
-download_and_check https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v0.11.0.tar.gz 7ed7dd3aca0a8f0971e87b56c19c60a1a4d654ee4cbbee9a5091b9d4cca28a34
+download_and_check https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v0.12.0.tar.gz 48e8f5c453290a077d29e43d7de7229cb697d8bf98e61ae2e129d45ce3a49ebf
 cd src
 phpize
 CFLAGS="$DEFAULT_FLAGS" ./configure --silent --enable-snuffleupagus

--- a/snuffleupagus-misp.rules
+++ b/snuffleupagus-misp.rules
@@ -1,9 +1,6 @@
 # Rules tailored for MISP
 # Copyright (C) 2022 National Cyber and Information Security Agency of the Czech Republic
 
-# Disable old PHP version warning
-sp.global.show_old_php_warning.disable();
-
 # Prevent the execution of writeable PHP files.
 sp.readonly_exec.no_extended_checks().enable();
 


### PR DESCRIPTION
Snuffleupagus 0.12.0 was released yesterday (https://dustri.org/b/snuffleupagus-0120-stegodontidae.html)

This PR updates the version with shasum and removes a now deprecated rule/breaking change (Snuffleupagus will no longer report outdated PHP versions)