### PR TITLE
Patch/redis port config

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -11,7 +11,7 @@ $plugin['ZeroMQ_username'] = '{{ ZEROMQ_USERNAME }}';
 $plugin['ZeroMQ_password'] = {{ ZEROMQ_PASSWORD | str }};
 {% endif %}
 $plugin['ZeroMQ_redis_host'] = '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}';
-$plugin['ZeroMQ_redis_port'] = 6379;
+$plugin['ZeroMQ_redis_port'] = {{ REDIS_PORT | default('6379') | int }};
 $plugin['ZeroMQ_redis_password'] = {{ REDIS_PASSWORD | str }};
 $plugin['ZeroMQ_redis_database'] = 10;
 {% endif %}
@@ -95,7 +95,7 @@ $config = [
     'uuid' => '{{ MISP_UUID }}',
     'host_org_id' => {{ MISP_HOST_ORG_ID }},
     'redis_host' => '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}',
-    'redis_port' => 6379,
+    'redis_port' => {{ REDIS_PORT | default('6379') | int }},
     'redis_database' => 13,
     'redis_password' => {{ REDIS_PASSWORD | str }},
     'log_client_ip' => true,
@@ -129,7 +129,7 @@ $config = [
   'SimpleBackgroundJobs' => [
     'enabled' => true,
     'redis_host' => '{{ "tls://" if REDIS_USE_TLS else "" }}{{ REDIS_HOST }}',
-    'redis_port' => 6379,
+    'redis_port' => {{ REDIS_PORT | default('6379') | int }},
     'redis_password' => {{ REDIS_PASSWORD | str }},
     'redis_database' => 11,
     'redis_namespace' => 'background_jobs',

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ MISP requires MySQL or MariaDB database.
 By default, MISP requires Redis. MISP will connect to Redis defined in `REDIS_HOST` variable on port `6379`. Redis alternative [Dragonfly](https://www.dragonflydb.io) is also supported.
 
 * `REDIS_HOST` (required, string) - hostname or IP address
+* `REDIS_PORT` (optional, int, default `6379`) - port used when connecting to redis
 * `REDIS_PASSWORD` (optional, string) - password used to connect password-protected Redis instance
 * `REDIS_USE_TLS` (optional, bool) - enable encrypted communication
 

--- a/bin/misp_create_configs.py
+++ b/bin/misp_create_configs.py
@@ -144,6 +144,7 @@ VARIABLES = {
     "MYSQL_FLAGS": Option(required=False, parser=parse_mysql_settings),
     # Redis
     "REDIS_HOST": Option(required=True),
+    "REDIS_PORT": Option(typ=int, default=6379, validation=check_uint),
     "REDIS_PASSWORD": Option(sensitive=True),
     "REDIS_USE_TLS": Option(typ=bool, default=False),
     # Proxy
@@ -382,13 +383,12 @@ def generate_jit_config(enabled: bool):
 
     write_file("/etc/php.d/10-opcache-jit.ini", config)
 
-
-def generate_sessions_in_redis_config(enabled: bool, redis_host: str, redis_use_tls: Optional[bool] = False, redis_password: Optional[str] = None):
+def generate_sessions_in_redis_config(enabled: bool, redis_host: str, redis_port: int, redis_use_tls: Optional[bool] = False, redis_password: Optional[str] = None):
     if not enabled:
         return
 
     scheme = "tls" if redis_use_tls else "tcp"
-    redis_path = f"{scheme}://{redis_host}:6379?database=12"
+    redis_path = f"{scheme}://{redis_host}:{redis_port}?database=12"
     if redis_password:
         redis_password = quote_plus(redis_password)
         redis_path = f"{redis_path}&auth={redis_password}"
@@ -604,7 +604,7 @@ def create():
     generate_xdebug_config(variables["PHP_XDEBUG_ENABLED"], variables["PHP_XDEBUG_PROFILER_TRIGGER"])
     generate_snuffleupagus_config(variables['PHP_SNUFFLEUPAGUS'])
     generate_jit_config(not variables['PHP_SNUFFLEUPAGUS']) # PHP JIT is not supported when snuffleupagus is enabled
-    generate_sessions_in_redis_config(variables["PHP_SESSIONS_IN_REDIS"], variables["REDIS_HOST"], variables["REDIS_USE_TLS"], variables["REDIS_PASSWORD"])
+    generate_sessions_in_redis_config(variables["PHP_SESSIONS_IN_REDIS"], variables["REDIS_HOST"], variables["REDIS_PORT"], variables["REDIS_USE_TLS"], variables["REDIS_PASSWORD"])
     generate_apache_config(variables)
     generate_rsyslog_config(variables)
     generate_vector_config(variables)

--- a/bin/misp_redis_ready.py
+++ b/bin/misp_redis_ready.py
@@ -23,8 +23,6 @@ def convert_bool(value: str) -> bool:
     error(f"Environment variable 'REDIS_USE_TLS' must be boolean (`true`, `1`, `yes`, `false`, `0` or `no`), `{value}` given")
 
 
-
-
 def connect(host: str, port: int, password: Optional[str] = None, use_tls: bool = False) -> redis.Redis:
     r = redis.Redis(host=host, port=port, password=password, ssl=use_tls)
     r.ping()

--- a/bin/misp_redis_ready.py
+++ b/bin/misp_redis_ready.py
@@ -23,23 +23,25 @@ def convert_bool(value: str) -> bool:
     error(f"Environment variable 'REDIS_USE_TLS' must be boolean (`true`, `1`, `yes`, `false`, `0` or `no`), `{value}` given")
 
 
-def connect(host: str, password: Optional[str] = None, use_tls: bool = False) -> redis.Redis:
-    r = redis.Redis(host=host, port=6379, password=password, ssl=use_tls)
+
+
+def connect(host: str, port: int, password: Optional[str] = None, use_tls: bool = False) -> redis.Redis:
+    r = redis.Redis(host=host, port=port, password=password, ssl=use_tls)
     r.ping()
     return r
 
 
-def wait_for_connection(host: str, password: Optional[str] = None, use_tls: bool = False) -> redis.Redis:
-    logging.info(f"Connecting to Redis server {host}")
+def wait_for_connection(host: str, port: int, password: Optional[str] = None, use_tls: bool = False) -> redis.Redis:
+    logging.info(f"Connecting to Redis server {host}:{port}")
     last_exception = None
     for i in range(1, 10):
         try:
-            return connect(host, password, use_tls)
+            return connect(host, port, password, use_tls)
         except Exception as e:
             last_exception = e
             logging.info("Waiting for Redis connection...")
             time.sleep(1)
-    logging.error(f"Could not connect to Redis server {host}")
+    logging.error(f"Could not connect to Redis server {host}:{port}")
     print(last_exception, file=sys.stderr)
     sys.exit(1)
 
@@ -73,6 +75,10 @@ def get_connection_info() -> Tuple[str, Optional[str], bool]:
     host = os.environ.get("REDIS_HOST")
     if host is None:
         error("Environment variable 'REDIS_HOST' not set.")
+        
+    port = os.environ.get("REDIS_PORT")
+    if port is None:
+        port = 6379
 
     password = os.environ.get("REDIS_PASSWORD")
 
@@ -85,8 +91,8 @@ def get_connection_info() -> Tuple[str, Optional[str], bool]:
 def main():
     logging.basicConfig(format="%(asctime)s - %(levelname)s: %(message)s", level=logging.DEBUG)
 
-    host, password, use_tls = get_connection_info()
-    redis = wait_for_connection(host, password, use_tls)
+    host, port, password, use_tls = get_connection_info()
+    redis = wait_for_connection(host, port, password, use_tls)
 
     info = redis.info("server")
     logging.info(f"Connected to Redis {info['redis_version']}")


### PR DESCRIPTION
We're sometimes using a Redis/Valkey cluster with separate instances running on different ports, therefore there is need to introduce the REDIS_PORT variable to make the port configurable.

Have tested and verified normal operations but **not ZeroMQ** since we're not using the functionality (But dont see why it should not work).